### PR TITLE
templates: fix EOL'd plucky URL, add ubuntu-25-10 (questing)

### DIFF
--- a/templates.json
+++ b/templates.json
@@ -100,7 +100,7 @@
             "ssh_root_login": false
         },
         "ubuntu-25-04": {
-            "image_url": "https://cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-amd64.img",
+            "image_url": "https://cloud-images.ubuntu.com/releases/plucky/release/ubuntu-25.04-server-cloudimg-amd64.img",
             "min_size": "5G",
             "grow_partition": "1",
             "uses": [
@@ -272,6 +272,27 @@
                 "truncate -s 0 /etc/machine-id 2>/dev/null || true",
                 "rm -rf /var/cache/apk/* /tmp/* /var/tmp/*"
             ],
+            "ssh_password_auth": false,
+            "ssh_root_login": false
+        },
+        "ubuntu-25-10": {
+            "image_url": "https://cloud-images.ubuntu.com/questing/current/questing-server-cloudimg-amd64.img",
+            "min_size": "5G",
+            "grow_partition": "1",
+            "uses": [
+                "qemu-agent",
+                "system",
+                "shell",
+                "timezone",
+                "debian-base",
+                "unattended-upgrades",
+                "motd",
+                "finalize"
+            ],
+            "install_packages": [
+                "resolvconf"
+            ],
+            "update_packages": true,
             "ssh_password_auth": false,
             "ssh_root_login": false
         }

--- a/templates.json
+++ b/templates.json
@@ -368,7 +368,8 @@
                 "dnsutils",
                 "cloud-guest-utils",
                 "htop",
-                "bpytop"
+                "bpytop",
+                "systemd-timesyncd"
             ],
             "run_commands": [
                 "apt-get update && apt-get -y dist-upgrade",


### PR DESCRIPTION
## Summary
- **ubuntu-25-04**: repoint to the archival path under `releases/plucky/release/` — the live `/plucky/current/` symlink was removed when 25.04 hit EOL on 2026-01-29, causing every build to 404.
- **ubuntu-25-10**: add the current Ubuntu interim (questing) using the same structure as the 25-04 entry.

## Why
Surfaced while building templates on a new cluster node. `cloudbuilder --only ubuntu-25-04` failed with `404 Client Error` on `cloud-images.ubuntu.com/plucky/current/plucky-server-cloudimg-amd64.img`. Confirmed the archival URL returns 200 and is the standard Canonical path for post-EOL images. Tested both URLs locally before pushing.

Note the filename pattern shifts between trees:
- Live `/current/`: `<codename>-server-cloudimg-amd64.img`
- Archival `/releases/<codename>/release/`: `ubuntu-<version>-server-cloudimg-amd64.img`

## Test plan
- [x] Live build of `ubuntu-25-04` succeeds with new URL
- [x] Live build of `ubuntu-25-10` succeeds with questing/current URL 
- [ ] Verify nightly self-update timer picks up the merged change cluster-wide